### PR TITLE
[QUAL-3332] Pin simplecove-html for our Ruby version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,9 @@ source 'https://rubygems.org'
 
 gemspec
 
+# TODO: Update this pin to to ~0.11.0. when we upgrade to Ruby > 2.4
+gem 'simplecov-html', '0.10.2'
+
 group :test, :development do
   if RUBY_ENGINE == 'jruby'
     gem 'activerecord-jdbc-adapter'


### PR DESCRIPTION
https://cloudhealthtech.atlassian.net/browse/QUAL-3332

Fixes
```13:55:52  Installing simplecov-html 0.11.0
13:55:52  Gem::RuntimeRequirementNotMetError: simplecov-html requires Ruby version ~> 2.4.
13:55:52  The current ruby version is 2.3.3.222.
13:55:52  An error occurred while installing simplecov-html (0.11.0), and Bundler cannot
13:55:52  continue.
13:55:52  Make sure that `gem install simplecov-html -v '0.11.0' --source
13:55:52  'https://rubygems.org/'` succeeds before bundling.
13:55:52  
13:55:52  In rails_3.2.Gemfile:
13:55:52    simplecov-json was resolved to 0.2, which depends on
13:55:52      simplecov was resolved to 0.18.0, which depends on
13:55:52        simplecov-html
[Pipeline] }
[Pipeline] // stage
[Pipeline] }
[Pipeline] // timestamps
[Pipeline] sh
+ docker stop shared-app-master_284 redis-shared-2-3-7258
shared-app-master_284
redis-shared-2-3-7258
+ docker rm -f shared-app-master_284 redis-shared-2-3-7258
shared-app-master_284
redis-shared-2-3-7258
[Pipeline] }
[Pipeline] // node
[Pipeline] End of Pipeline

GitHub has been notified of this commit’s build result

ERROR: script returned exit code 5
Finished: FAILURE```