### PR TITLE
[QUAL-3400] Use updated cloudpercept image as base

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,12 +21,8 @@ node('management-testing') {
             stage('Setup_2.3.3-3.0') {
 
                 checkout scm
-                withCredentials([sshUserPrivateKey(credentialsId: 'github', keyFileVariable: 'GIT_SSH_KEY')]) {
-                  sh 'cp -n $GIT_SSH_KEY docker/config/ssh/id_rsa'
-                  sh "docker build -f docker/Dockerfile -t ar_ondemand_image ."
-                  sh "docker run -dit --name=ar_ondemand-app-${JOB_BASE_NAME}_${BUILD_NUMBER} -e RAILS_ENV=test -v \"${WORKSPACE}/docker/config/ssh/:/home/cloudhealth/.ssh/\" -v ${WORKSPACE}/:/home/cloudhealth/ar-ondemand/ ar_ondemand_image /bin/bash"
-                }
-
+                sh "docker build -f docker/Dockerfile -t ar_ondemand_image ."
+                sh "docker run -dit --name=ar_ondemand-app-${JOB_BASE_NAME}_${BUILD_NUMBER} -e RAILS_ENV=test -v ${WORKSPACE}/:/home/cloudhealth/ar-ondemand/ ar_ondemand_image /bin/bash"
            }
 
         }
@@ -36,7 +32,6 @@ node('management-testing') {
             stage('Run Bundle Install') {
 
                 sh "docker exec ar_ondemand-app-${JOB_BASE_NAME}_${BUILD_NUMBER} /bin/bash -c  -l 'bundle install --no-deployment --binstubs=bin'"
-                sh 'rm -rv docker/config/ssh/id_rsa'
 
             }
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,38 +1,19 @@
-FROM ubuntu:14.04
+FROM 297322132092.dkr.ecr.us-east-1.amazonaws.com/cloudpercept/app:ubuntu18-base
 
-# Install https packages for apt
-RUN apt-get update && apt-get install -y apt-transport-https ca-certificates
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv 1655a0ab68576280 && apt-key update && apt-get update
+USER root
+# Setup access to github
+RUN mkdir -p /home/cloudhealth/.ssh
+ADD docker/config/ssh/config /home/cloudhealth/.ssh/config
+RUN chmod 700 /home/cloudhealth/.ssh /home/cloudhealth/.ssh/* && chown -R cloudhealth:cloudhealth /home/cloudhealth/.ssh /home/cloudhealth/.ssh/*
+ADD docker/config/ssh/id_rsa /home/cloudhealth/.ssh/id_rsa
+RUN chown cloudhealth:cloudhealth /home/cloudhealth/.ssh/id_rsa && chmod 600 /home/cloudhealth/.ssh/id_rsa
 
-# Install necessary apt packages
-RUN apt-get install -y build-essential libxml2-dev libxslt-dev git curl g++ gcc curl \
-&& apt-get clean
+COPY --chown=cloudhealth:cloudhealth . /home/cloudhealth/ar-ondemand
 
-RUN gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
-RUN curl -sSL https://get.rvm.io | bash -s stable
-RUN /bin/bash -l -c "rvm install 2.3.3"
-RUN /bin/bash -l -c "rvm use 2.3.3"
-RUN /bin/bash -l -c "echo 'gem: --no-ri --no-rdoc' > ~/.gemrc"
-RUN /bin/bash -l -c "gem install bundler -v "1.16.2" --no-ri --no-rdoc"
-
-# Setup cloudhealth user
-RUN useradd -d /home/cloudhealth/ -m cloudhealth
-
-ADD docker/config/bundle/config /home/cloudhealth/.bundle/config
-RUN chown -R cloudhealth:cloudhealth /home/cloudhealth/.bundle/
-
-RUN mkdir -p /home/cloudhealth/ar-ondemand
-RUN mkdir -p /home/cloudhealth/ar-ondemand/lib
-RUN mkdir -p /home/cloudhealth/ar-ondemand/lib/ar-ondemand
-
-# Copying Gemfile and related files
-COPY Gemfile /home/cloudhealth/ar-ondemand
-COPY ar-ondemand.gemspec /home/cloudhealth/ar-ondemand
-COPY lib/ar-ondemand/version.rb /home/cloudhealth/ar-ondemand/lib/ar-ondemand
-
-RUN chown -R cloudhealth:cloudhealth /home/cloudhealth/ar-ondemand
-
-WORKDIR /home/cloudhealth/ar-ondemand
 USER cloudhealth
+WORKDIR /home/cloudhealth/ar-ondemand
 
-RUN /bin/bash -c -l "USE_SYSTEM_GECODE=1 RAILS_ENV=test bundle install --no-deployment --binstubs=bin"
+RUN /bin/bash -c -l "bundle --version"
+RUN /bin/bash -c -l "RAILS_ENV=test BUNDLE_GEMFILE=rails_3.2.Gemfile bundle install --no-deployment --binstubs=bin"
+
+RUN rm /home/cloudhealth/.ssh/id_rsa

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,12 +1,6 @@
 FROM 297322132092.dkr.ecr.us-east-1.amazonaws.com/cloudpercept/app:ubuntu18-base
 
 USER root
-# Setup access to github
-RUN mkdir -p /home/cloudhealth/.ssh
-ADD docker/config/ssh/config /home/cloudhealth/.ssh/config
-RUN chmod 700 /home/cloudhealth/.ssh /home/cloudhealth/.ssh/* && chown -R cloudhealth:cloudhealth /home/cloudhealth/.ssh /home/cloudhealth/.ssh/*
-ADD docker/config/ssh/id_rsa /home/cloudhealth/.ssh/id_rsa
-RUN chown cloudhealth:cloudhealth /home/cloudhealth/.ssh/id_rsa && chmod 600 /home/cloudhealth/.ssh/id_rsa
 
 COPY --chown=cloudhealth:cloudhealth . /home/cloudhealth/ar-ondemand
 


### PR DESCRIPTION
- Use an updated version of the cloudpercept base image that doesn't use RVM
- Update the ar-ondemand Dockerfiles for ruby 2.3.3 and ruby 2.5.5 to pull from the updated cloudpercept image

- tested with https://github.com/CloudHealth/cloudpercept/pull/18160/files