### PR TITLE
Pin gem 'unicode-display_width' to last working version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ gemspec
 
 # TODO: Update this pin to to ~0.11.0. when we upgrade to Ruby > 2.4
 gem 'simplecov-html', '0.10.2'
+gem 'unicode-display_width', '2.3'
 
 group :test, :development do
   if RUBY_ENGINE == 'jruby'


### PR DESCRIPTION
https://rubygems.org/gems/unicode-display_width/versions/2.3.0

Build failure without pin: https://jenkins.mgmt.cloudhealthtech.com/view/Becky's%20Deployment%20Lair/job/CloudHealth%20-%20Build%20and%20Test/job/ar-ondemand/job/master/242/console

10:19:38  Installing unicode-display_width 2.4.2
10:19:38  Gem::InstallError: unicode-display_width requires Ruby version >= 2.4.0.
